### PR TITLE
Create a custom notetype with most Readwise fields 

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -24,6 +24,7 @@ import openai  # noqa: E402
 
 from .readwise import ReadwiseClient
 from .logging_utils import make_logger
+from .notetype import SmoothBrainNotetype
 
 LOG_FILE = os.path.join(ADDON_ROOT_DIR, f"{__name__}.log")
 logger = make_logger(__name__, filepath=LOG_FILE)
@@ -67,6 +68,7 @@ def make_flashcard(doc, highlight, openai_response):
 
 def do_sync():
     def op(col: Collection):
+        notetype = SmoothBrainNotetype(col)
         want_cancel = False
         def update_progress(label, value=None, max=None):
             def cb():
@@ -86,12 +88,7 @@ def do_sync():
             completions = get_ai_flashcards_for_doc(doc)
             completions = [c.choices[0].text.strip() for c in completions]
             for hl, completion in zip(doc.highlights, completions):
-                question, answer = completion.split("A:")
-                question = question[len("Q: "):]
-                model = mw.col.models.by_name("Basic")
-                note = mw.col.new_note(model)
-                note["Front"] = question
-                note["Back"] = answer
+                note = notetype.new_note(doc, hl, completion)
                 col.add_note(note=note, deck_id=deck_id)
         # NOTE: the undo queue is limited to 30, so we can't merge more than that
         # maybe an add_notes() op should be added to Anki

--- a/notetype.py
+++ b/notetype.py
@@ -1,0 +1,106 @@
+from anki.collection import Collection
+from anki.models import NotetypeDict
+from anki.notes import Note
+from anki.stdmodels import get_stock_notetypes
+from markdown import markdown
+
+from .readwise import ReadwiseDocument, ReadwiseHighlight
+
+
+class SmoothBrainBasicTemplate:
+    name = "Card 1"
+    question = """{{question}}"""
+    answer = """{{FrontSide}}
+
+<hr id=answer>
+
+{{answer}}"""
+
+
+class SmoothBrainNotetype:
+    name = "SmoothBrain"
+    templates = [SmoothBrainBasicTemplate]
+    fields = [
+        "id",
+        "question",
+        "answer",
+        # Highlight fields
+        "text",
+        "note",
+        "url",
+        "readwise_url",
+        "highlighted_at",
+        "created_at",
+        "updated_at",
+        # Document fields
+        "book_id",
+        "title",
+        "author",
+        "source",
+        "source_url",
+        "asin",
+    ]
+
+    def __init__(self, col: Collection) -> None:
+        self.col = col
+        basic_notetype = get_stock_notetypes(col)[0][1](col)
+        self.css = basic_notetype["css"]
+        self.notetype = self._ensure_exists()
+
+    def _ensure_exists(self) -> NotetypeDict:
+        notetype = self.col.models.by_name(self.name)
+        if not notetype:
+            notetype = self.col.models.new(self.name)
+            for readwise_template in self.templates:
+                template = self.col.models.new_template(readwise_template.name)
+                template["qfmt"] = readwise_template.question
+                template["afmt"] = readwise_template.answer
+                self.col.models.add_template(notetype, template)
+            for field_name in self.fields:
+                field = self.col.models.new_field(field_name)
+                self.col.models.add_field(notetype, field)
+            notetype["css"] = self.css
+            self.col.models.set_sort_index(notetype, self.fields.index("question"))
+            self.col.models.add_dict(notetype)
+            # We need to refetch the notetype after adding it
+            notetype = self.col.models.by_name(self.name)
+        return notetype
+
+    def _format_field(self, contents) -> str:
+        text = ""
+        if contents:
+            text = str(contents)
+        return text
+
+    def _format_url(self, contents) -> str:
+        url = self._format_field(contents)
+        if url:
+            url = f'<a href="{url}">{url}</a>'
+        return url
+
+    def new_note(
+        self, doc: ReadwiseDocument, highlight: ReadwiseHighlight, completion: str
+    ) -> Note:
+        note = self.col.new_note(self.notetype)
+        question, answer = completion.split("A:")
+        question = question[len("Q: ") :]
+        note = self.col.new_note(self.notetype)
+        note["id"] = self._format_field(highlight.id)
+        note["question"] = self._format_field(question)
+        note["answer"] = self._format_field(answer)
+        note["text"] = markdown(self._format_field(highlight.text))
+        note["note"] = self._format_field(highlight.note)
+        note["url"] = self._format_url(highlight.url)
+        note["readwise_url"] = self._format_url(highlight.readwise_url)
+        note["highlighted_at"] = self._format_field(highlight.highlighted_at)
+        note["created_at"] = self._format_field(highlight.created_at)
+        note["updated_at"] = self._format_field(highlight.updated_at)
+        note["book_id"] = self._format_field(doc.user_book_id)
+        note["title"] = self._format_field(doc.readable_title)
+        note["author"] = self._format_field(doc.author)
+        note["source"] = self._format_field(doc.source)
+        note["source_url"] = self._format_url(doc.source_url)
+        note["asin"] = self._format_field(doc.asin)
+        note.tags = [tag["name"] for tag in doc.book_tags + highlight.tags]
+
+        return note

--- a/notetype.py
+++ b/notetype.py
@@ -38,6 +38,7 @@ class SmoothBrainNotetype:
         "author",
         "source",
         "source_url",
+        "category",
         "asin",
     ]
 
@@ -100,6 +101,7 @@ class SmoothBrainNotetype:
         note["author"] = self._format_field(doc.author)
         note["source"] = self._format_field(doc.source)
         note["source_url"] = self._format_url(doc.source_url)
+        note["category"] = self._format_field(doc.category)
         note["asin"] = self._format_field(doc.asin)
         note.tags = [tag["name"] for tag in doc.book_tags + highlight.tags]
 

--- a/notetype.py
+++ b/notetype.py
@@ -32,12 +32,22 @@ class SmoothBrainNotetype:
         "highlighted_at",
         "created_at",
         "updated_at",
+        "location",
+        "end_location",
+        "color",
+        "is_favorite",
+        "is_discard",
         # Document fields
-        "book_id",
+        "user_book_id",
+        "readable_title",
         "title",
+        "document_note",
+        "document_readwise_url",
         "author",
         "source",
         "source_url",
+        "unique_url",
+        "cover_image_url",
         "category",
         "asin",
     ]
@@ -79,6 +89,12 @@ class SmoothBrainNotetype:
             url = f'<a href="{url}">{url}</a>'
         return url
 
+    def _format_image(self, contents) -> str:
+        url = self._format_field(contents)
+        if url:
+            url = f'<img src="{url}">'
+        return url
+
     def new_note(
         self, doc: ReadwiseDocument, highlight: ReadwiseHighlight, completion: str
     ) -> Note:
@@ -96,11 +112,21 @@ class SmoothBrainNotetype:
         note["highlighted_at"] = self._format_field(highlight.highlighted_at)
         note["created_at"] = self._format_field(highlight.created_at)
         note["updated_at"] = self._format_field(highlight.updated_at)
-        note["book_id"] = self._format_field(doc.user_book_id)
-        note["title"] = self._format_field(doc.readable_title)
+        note["location"] = self._format_field(highlight.location)
+        note["end_location"] = self._format_field(highlight.end_location)
+        note["color"] = self._format_field(highlight.color)
+        note["is_favorite"] = self._format_field(highlight.is_favorite)
+        note["is_discard"] = self._format_field(highlight.is_discard)
+        note["user_book_id"] = self._format_field(doc.user_book_id)
+        note["readable_title"] = self._format_field(doc.readable_title)
+        note["title"] = self._format_field(doc.title)
+        note["document_note"] = self._format_field(doc.document_note)
+        note["document_readwise_url"] = self._format_url(doc.readwise_url)
         note["author"] = self._format_field(doc.author)
         note["source"] = self._format_field(doc.source)
         note["source_url"] = self._format_url(doc.source_url)
+        note["unique_url"] = self._format_url(doc.unique_url)
+        note["cover_image_url"] = self._format_image(doc.cover_image_url)
         note["category"] = self._format_field(doc.category)
         note["asin"] = self._format_field(doc.asin)
         note.tags = [tag["name"] for tag in doc.book_tags + highlight.tags]


### PR DESCRIPTION
Closes #5 and depends on #13

Most document and highlight fields are added, except the following:
- doc.document_note
- doc.readwise_url
- doc.title (readable_title is added instead; I'm not sure when they are different)
- doc.cover_image_url (we can either add it as a remote image link or download the image to the user's media folder and add local link; I vote for either omitting it or adding it as a remote link.)
- doc.unique_url
- highlight.location
- highlight.end_location
- highlight.location_type
- highlight.color (It would be nice to make this available so that the user can for example display the highlights in the same color by modifying the template, but I'm not sure yet how to choose the color in the Readwise website and how it's displayed there)
- highlight.is_favorite
- highlight..is_discard
